### PR TITLE
Include all projects

### DIFF
--- a/csdco-metadata-aggregator.py
+++ b/csdco-metadata-aggregator.py
@@ -119,7 +119,6 @@ def aggregate_metadata(database, outfile, **kwargs):
 def export_project_location_data(database, outfile, **kwargs):
   exclude_projects = kwargs['exclude_projects'] if 'exclude_projects' in kwargs else []
   debug_projects = kwargs['debug_projects'] if 'debug_projects' in kwargs else []
-  print(debug_projects)
 
   conn = sqlite3.connect('file:' + database + '?mode=ro', uri=True)
   cur = conn.cursor()

--- a/csdco-metadata-aggregator.py
+++ b/csdco-metadata-aggregator.py
@@ -106,8 +106,10 @@ def aggregate_metadata(database, outfile, **kwargs):
 
       csvwriter.writerow(aggregated_line)
     
-    for e in no_borehole_info:
-      aggregated_line = [e] + [project_metadata[e][0]] + ['']*3 + list(project_metadata[e][1:])
+    # Include projects that don't have information from the borehole table. In this case, leave
+    # location and named feature fields empty, but pull PI info from projects table also.
+    for e in sorted(list(no_borehole_info)):
+      aggregated_line = [e] + [project_metadata[e][0]] + ['']*2 + [project_metadata[e][-1]] + list(project_metadata[e][1:-1])
       csvwriter.writerow(aggregated_line)
 
   conn.close()


### PR DESCRIPTION
Include projects from the ```project``` table that don't have any associated data in the ```boreholes``` table yet. This most commonly occurs with projects in the proposal stage that haven't collected any core yet, but we are still supporting and should still be listed on our website.